### PR TITLE
[design] 22-idepage editor UI 구현 및 스크롤 기능 추가

### DIFF
--- a/frontend/src/pages/IDEPage/components/editor/components/CloseButton.jsx
+++ b/frontend/src/pages/IDEPage/components/editor/components/CloseButton.jsx
@@ -1,14 +1,18 @@
 import CloseIcon from "@mui/icons-material/Close";
 
-const CloseButton = ({ isActive }) => {
+const CloseButton = ({ isActive, onClick }) => {
   return (
     <button
       type="button"
       id="north_tab_close_btn"
       className="btn"
       data-container="body"
+      onClick={onClick}
     >
-      <CloseIcon fontSize="small" style={{ color: isActive ? "#609AE2" : "#C3C8CC" }} />
+      <CloseIcon
+        fontSize="small"
+        style={{ color: isActive ? "#609AE2" : "#C3C8CC" }}
+      />
     </button>
   );
 };

--- a/frontend/src/pages/IDEPage/components/editor/components/Tab.jsx
+++ b/frontend/src/pages/IDEPage/components/editor/components/Tab.jsx
@@ -1,22 +1,25 @@
-import React from 'react';
+import React from "react";
 import CloseButton from "./CloseButton";
 
 const Tab = ({ isActive, label, onClick, onClose }) => {
   return (
-    <li className="w-auto border-r border-gray-700 relative mt-1.5 mb-1.5 ml-2 ">
+    <li className="w-auto border-r border-gray-700 relative mt-1.5 mb-0.5 ml-2 ">
       <a
         onClick={onClick}
-        className={`flex items-center  h-full ${isActive ? 'bg-[#2C3243] pt-0 pb-0 border-t-2 rounded-xl border-[#609AE2] text-[#609AE2]' : 'text-[#C3C8CC]'} 
+        className={`flex items-center  h-full ${
+          isActive
+            ? "bg-[#2C3243] pt-0 pb-0 border-t-2 rounded-xl border-[#609AE2] text-[#609AE2]"
+            : "text-[#C3C8CC]"
+        } 
                    px-10 py-0 whitespace-nowrap text-center align-middle justify-center h-full`}
       >
-        <span className="tab-title text-sm font-bold overflow-hidden mr-2 truncate w-auto flex-1">{label}</span>
+        <span className="tab-title text-sm font-bold overflow-hidden mr-2 truncate w-auto flex-1">
+          {label}
+        </span>
       </a>
-      <button 
-        className="absolute top-0 right-0 mt-2 mr-2  text-[#609AE2]" 
-        onClick={onClose}
-      >
-        <CloseButton isActive={isActive} />
-      </button>
+      <div className="absolute top-0 right-0 mt-1 mr-2">
+        <CloseButton onClick={onClose} isActive={isActive} />
+      </div>
     </li>
   );
 };

--- a/frontend/src/pages/IDEPage/components/editor/index.css
+++ b/frontend/src/pages/IDEPage/components/editor/index.css
@@ -6,20 +6,42 @@
   width: auto;
   height: 100vh;
   visibility: visible;
+  box-sizing: content-box;
 }
 
 ul#north_tab.nav_tabs {
-    background-color: #1d2332;
-  }
+  background-color: #1d2332;
+  overflow-x: overlay; /*콘텐츠 위에 위치하고 싶어 넣었지만 적용이 안 되고 밑에 추가된 형식*/
+}
 
-  #north_tab {
-    border-top: 1px solid #0e1525;
-    border-left: 1px solid #0e1525;
-    flex-wrap: nowrap;
-    min-height: 48px;
-    margin-bottom: -1px;
-  }
+ul#north_tab.nav_tabs::-webkit-scrollbar {
+  height: 10px;
+}
 
+ul#north_tab.nav_tabs::-webkit-scrollbar-track {
+  background: #1d2332;
+}
+
+ul#north_tab.nav_tabs::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 16px;
+}
+
+ul#north_tab.nav_tabs:hover::-webkit-scrollbar-thumb {
+  background: #2c3243;
+}
+
+ul#north_tab.nav_tabs::-webkit-scrollbar-thumb:hover {
+  background: #414244;
+}
+
+#north_tab {
+  border-top: 1px solid #0e1525;
+  border-left: 1px solid #0e1525;
+  flex-wrap: nowrap;
+  min-height: 48px;
+  margin-bottom: -1px;
+}
 
 #north_tab > li > a:hover {
   background-color: #2c3243;
@@ -32,11 +54,14 @@ ul#north_tab.nav_tabs {
   display: flex;
   -webkit-box-align: center;
   align-items: center;
-  margin-top: -2px;
 }
 
 #north_tab > li {
-    border: solid 2px #2c3243;
-    cursor: pointer;
-    border-radius: 16px;
-  }
+  border: solid 2px #2c3243;
+  cursor: pointer;
+  border-radius: 16px;
+}
+
+body.no-scroll {
+  overflow: hidden;
+}

--- a/frontend/src/pages/IDEPage/components/editor/index.jsx
+++ b/frontend/src/pages/IDEPage/components/editor/index.jsx
@@ -1,15 +1,30 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import Tab from "./components/Tab";
 import "./index.css";
 
+//탭
 const Index = () => {
   const [activeTab, setActiveTab] = useState("Main.java");
-  const [tabs, setTabs] = useState(["Main.java", "index.jsx", "index.css"]);
-
+  const [tabs, setTabs] = useState([
+    "Main.java",
+    "index.jsx",
+    "index.css",
+    "index1.jsx",
+    "index2.jsx",
+    "index3.jsx",
+    "index4.jsx",
+    "index5.jsx",
+    "index6.jsx",
+    "index7.jsx",
+    "index8.jsx",
+    "index9.jsx",
+    "index0.jsx",
+  ]);
   const handleTabClick = (tab) => {
     setActiveTab(tab);
   };
 
+  //닫기 버튼
   const handleCloseTab = (tabToClose) => {
     setTabs(tabs.filter((tab) => tab !== tabToClose));
     if (activeTab === tabToClose) {
@@ -17,12 +32,34 @@ const Index = () => {
     }
   };
 
+   //스크롤
+  const tabsRef = useRef(null);
+  const handleWheel = (e) => {
+    e.stopPropagation();
+    const container = tabsRef.current;
+    const containerScrollPosition = container.scrollLeft;
+    container.scrollLeft = containerScrollPosition + e.deltaY;
+  };
+
+  //스크롤 숨김, 스크롤 동시에 작동 안 하게
+  const handleMouseEnter = () => {
+    document.body.classList.add("no-scroll");
+  };
+  const handleMouseLeave = () => {
+    document.body.classList.remove("no-scroll");
+  };
+
   return (
-    <div
-      id="inner_layout_top"
-      className="bg-[#0E1525] overflow-hidden"
-    >
-      <ul id="north_tab" className="nav nav_tabs" style={{ display: "flex" }}>
+    <div id="inner_layout_top" className="bg-[#0E1525] overflow-hidden">
+      <ul
+        ref={tabsRef}
+        onWheel={handleWheel}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        id="north_tab"
+        className="nav nav_tabs"
+        style={{ display: "flex" }}
+      >
         {tabs.map((tab, index) => (
           <Tab
             key={index}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?

## 작업 내용
- 스크롤 UI (hover 시에만 보이게)
- 에디터 nav 에서 스크롤 할 시 전체 스크롤과 동시에 안 움직이는 기능
- tab ui 수정

## 스크린샷
![22issue editor UI 추가](https://github.com/NaKaLiGoBa/WebIDE/assets/135569766/79069734-f134-4823-8767-3bcc22b0030b)

## 주의사항
콘텐츠 위에 스크롤 바를 위치하고 싶어 여러 시도를 했지만 적용이 안 되었습니다
-> 닫기 버튼과 탭 위치 수정하고 일단 밑에 추가했습니다


Closes #{issueNumber}
