### PR TITLE
[feat] reset-password UI 구현 및 api추가, 로그인 시 user 데이터 전송

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,8 @@
   import IDEPage from "./pages/IDEPage";
   import LoginPage from "./pages/LoginPage/components/login";
   import SignUpPage from "./pages/LoginPage/components/signup"
+  import PasswordEmailPage from "./pages/LoginPage/components/password/passwordemail"
+  import PasswordResetPage from "./pages/LoginPage/components/password/passwordreset"
 
   import { Routes, Route, BrowserRouter } from "react-router-dom";
 
@@ -15,6 +17,8 @@
           <Route path="/" element={<LoginPage />} />
           <Route path="/idepage" element={<IDEPage />} />
           <Route path="/signup" element={<SignUpPage />} />
+          <Route path="/password" element={<PasswordEmailPage />} />
+          <Route path="/password/reset" element={<PasswordResetPage />} />
         </Routes>
       </BrowserRouter>
     );

--- a/frontend/src/pages/IDEPage/index.jsx
+++ b/frontend/src/pages/IDEPage/index.jsx
@@ -25,7 +25,7 @@ const index = () => {
   useEffect(() => {
     const fetchUserData = async () => {
       try {
-        const response = await axiosInstance.get("user");
+        const response = await axiosInstance.get("projects");
         setUser(response.data);
       } catch (error) {
         console.error("Error fetching user data: ", error);

--- a/frontend/src/pages/IDEPage/index.jsx
+++ b/frontend/src/pages/IDEPage/index.jsx
@@ -5,36 +5,54 @@ import FileExplorer from "./components/file_explorer";
 import Header from "./components/header";
 import Sidebar from "./components/sidebar";
 import Modal from "./components/modal";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import axiosInstance from "../../service/axiosInstance";
 
 const index = () => {
   const [onModalClick, setOnModalClick] = useState(true);
-  const [modal,setModal] =React.useState(false);
-
+  const [modal, setModal] = React.useState(false);
 
   const projectBtnHandler = (isOn) => {
     setOnModalClick(isOn);
   };
 
-  const createModal= ()=> {
-    setModal((prev)=>!prev);
-  }
+  const createModal = () => {
+    setModal((prev) => !prev);
+  };
 
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const fetchUserData = async () => {
+      try {
+        const response = await axiosInstance.get("user");
+        setUser(response.data);
+      } catch (error) {
+        console.error("Error fetching user data: ", error);
+      }
+    };
+    fetchUserData();
+  }, []);
 
   return (
     <div>
-    {onModalClick && <Modal 
-                        onProjClick={projectBtnHandler} 
-                        modal ={modal} 
-                        setModal={setModal} 
-                        createModal={createModal}
-                  
-                        />}
+      {onModalClick && (
+        <Modal
+          onProjClick={projectBtnHandler}
+          modal={modal}
+          setModal={setModal}
+          createModal={createModal}
+          user={user} // 사용자 데이터를 prop으로 전달
+        />
+      )}
       <div className="flex flex-col h-screen relative">
         <Header onProjClick={projectBtnHandler} />
         <div className="flex flex-row h-full">
           <div className="flex flex-row w-1/4">
-            <Sidebar createModal={createModal} projectBtnHandler={projectBtnHandler}/>
+            <Sidebar
+              createModal={createModal}
+              projectBtnHandler={projectBtnHandler}
+            />
             <FileExplorer />
           </div>
           <div className="flex flex-col w-3/4 h-full">

--- a/frontend/src/pages/LoginPage/components/login/index.jsx
+++ b/frontend/src/pages/LoginPage/components/login/index.jsx
@@ -23,10 +23,6 @@ const index = () => {
   // 로그인 에러 상태 관리
   const [errorMessage, setErrorMessage] = useState("");
 
-  // // 테스트
-  // const testEmail = "asd";
-  // const testPassword = "asd";
-
   const checkLogin = async () => {
     if (!loginValues.email && !loginValues.password) {
       setErrorMessage("이메일을 입력해주세요");
@@ -46,28 +42,37 @@ const index = () => {
           password: loginValues.password,
         }
       );
-      if (response.data && response.data.accessToken) {
-        localStorage.setItem("token", response.data.accessToken);
-        setErrorMessage(""); // 에러 상태 초기화
-        navigate("/idepage");
+      if (response.status === 200) {
+        // 성공 로직
+        if (response.data && response.data.accessToken) {
+          localStorage.setItem("token", response.data.accessToken);
+          setErrorMessage(""); // 에러 상태 초기화
+          navigate("/idepage");
+        } else {
+          setErrorMessage("로그인에 실패했습니다. 다시 시도해 주세요.");
+        }
+      } else if (response.status === 401) {
+        // 권한 없음, 로그인 실패 로직
+        setErrorMessage("이메일 또는 비밀번호가 일치하지 않습니다.");
       } else {
-        setErrorMessage("로그인에 실패했습니다. 다시 시도해 주세요.");
+        // 기타 에러 로직
+        setErrorMessage("서버에서 오류가 발생하였습니다. 다시 시도해 주세요.");
       }
     } catch (error) {
       //로그인 에러 표시
       console.error("Login Error:", error);
-      setErrorMessage("로그인에 실패했습니다. 다시 시도해 주세요.");
+      if (
+        error.response &&
+        error.response.data &&
+        error.response.data.message
+      ) {
+        // 서버에서 에러 메시지를 제공하는 경우
+        setErrorMessage(error.response.data.message);
+      } else {
+        // 그 외의 클라이언트 측에서 잡힌 에러
+        setErrorMessage("로그인에 실패하였습니다. 다시 시도해 주세요.");
+      }
     }
-    // //테스트
-    // if (
-    //   loginValues.email === testEmail &&
-    //   loginValues.password === testPassword
-    // ) {
-    //   setErrorMessage(""); // 에러 상태 초기화
-    //   navigate("/idepage");
-    // } else {
-    //   setErrorMessage("이메일이나 비밀번호가 틀립니다"); // 로그인 에러 표시
-    // }
   };
 
   const handleKakaoLogin = () => {
@@ -130,8 +135,10 @@ const index = () => {
               >
                 <span className="text-white text-sm font-bold">로그인</span>
               </div>
-              <div className="my-2 text-center"
-              onClick={() => navigate("password")}>
+              <div
+                className="my-2 text-center"
+                onClick={() => navigate("password")}
+              >
                 <span className="text-sm font-bold text-blue-600 cursor-pointer ">
                   비밀번호 찾기
                 </span>

--- a/frontend/src/pages/LoginPage/components/login/index.jsx
+++ b/frontend/src/pages/LoginPage/components/login/index.jsx
@@ -40,7 +40,7 @@ const index = () => {
     }
     try {
       const response = await axios.post(
-        "http://localhost:8080/api/v1/auth/signin",
+        "http://50.19.246.89:8080/api/v1/auth/signin",
         {
           email: loginValues.email,
           password: loginValues.password,
@@ -130,7 +130,8 @@ const index = () => {
               >
                 <span className="text-white text-sm font-bold">로그인</span>
               </div>
-              <div className="my-2 text-center">
+              <div className="my-2 text-center"
+              onClick={() => navigate("password")}>
                 <span className="text-sm font-bold text-blue-600 cursor-pointer ">
                   비밀번호 찾기
                 </span>

--- a/frontend/src/pages/LoginPage/components/password/passwordemail/index.jsx
+++ b/frontend/src/pages/LoginPage/components/password/passwordemail/index.jsx
@@ -11,7 +11,7 @@ const index = () => {
   // //테스트
   // const mock = new MockAdapter(axios);
   // mock
-  //   .onPost("http://50.19.246.89:8080/api/v1/auth/password/email?")
+  //   .onPost("http://50.19.246.89:8080/api/v1/auth/password/reset/email")
   //   .reply(200, {
   //     code: 200,
   //     message: "비밀번호 재설정 요청 성공",
@@ -28,7 +28,7 @@ const index = () => {
   const handlePasswordResetRequest = async () => {
     try {
       const response = await axios.post(
-        "http://50.19.246.89:8080/api/v1/auth/password/email?",
+        "http://50.19.246.89:8080/api/v1/auth/password/reset/email",
         {
           email,
         }

--- a/frontend/src/pages/LoginPage/components/password/passwordemail/index.jsx
+++ b/frontend/src/pages/LoginPage/components/password/passwordemail/index.jsx
@@ -1,0 +1,129 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import backImage from "../../../background.png";
+import logoImage from "../../../네카라쿠배.png";
+import axios from "axios";
+// import MockAdapter from "axios-mock-adapter";
+
+const index = () => {
+  const navigate = useNavigate();
+
+  // //테스트
+  // const mock = new MockAdapter(axios);
+  // mock
+  //   .onPost("http://50.19.246.89:8080/api/v1/auth/password/email?")
+  //   .reply(200, {
+  //     code: 200,
+  //     message: "비밀번호 재설정 요청 성공",
+  //   });
+
+  const [email, setEmail] = useState(""); // 이메일 상태 관리
+  const [message, setMessage] = useState(""); // 메시지 상태 관리
+
+  const handleEmailChange = (e) => {
+    setEmail(e.target.value); // 이메일 상태 업데이트
+  };
+
+  // 비밀번호 재설정 요청 핸들링 함수
+  const handlePasswordResetRequest = async () => {
+    try {
+      const response = await axios.post(
+        "http://50.19.246.89:8080/api/v1/auth/password/email?",
+        {
+          email,
+        }
+      );
+      if (response.data && response.status === 200) {
+        // 성공적인 응답을 처리
+        setMessage(response.data.message);
+      } else {
+        // 에러 응답을 처리
+        setMessage(response.data.message);
+      }
+    } catch (error) {
+      console.error("Failed to fetch:", error);
+      setMessage(
+        "비밀번호 재설정 요청 중 오류가 발생했습니다. 다시 시도해주세요."
+      );
+    }
+  };
+
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center bg-transparent"
+      style={{
+        backgroundImage: `url(${backImage})`,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+      }}
+    >
+      <div>
+        <div className="flex flex-row bg-white rounded-2xl">
+          <div className="w-96 h-full">
+            <div className="border border-gray-300 p-12 rounded-2xl">
+              <div className="pb-10 w-full">
+                <img
+                  className="w-full h-16"
+                  src={logoImage}
+                  alt="로고 이미지"
+                />
+                <div className="mt-8 text-center">
+                  <span className="text-2xl font-bold">
+                    비밀번호를 재설정합니다.
+                  </span>
+                </div>
+                <div className="mt-4 text-center">
+                  <span className="text-sm font-medium">
+                    비밀번호를 재설정할
+                  </span>
+                </div>
+                <div className="mb-7 text-center">
+                  <span className="text-sm font-medium">
+                    계정의 이메일을 입력해 주세요.
+                  </span>
+                </div>
+                <div>
+                  <input
+                    className="w-full flex-1 bg-gray-200 border border-gray-300 py-3 pl-2 shadow-lg hover:shadow-xl"
+                    type="text"
+                    name="email"
+                    placeholder="이메일"
+                    value={email}
+                    onChange={handleEmailChange}
+                  />
+                  <button
+                    className="mt-10 w-full flex-shrink-0 bg-white border border-blue-600 rounded-2xl hover:bg-blue-200 text-blue-600 px-4 shadow-lg hover:shadow-xl h-12 "
+                    onClick={handlePasswordResetRequest}
+                  >
+                    비밀번호 재설정
+                  </button>
+                  {message && (
+                    <div className="mt-12 text-center">
+                      <p>{message}</p>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className="flex justify-between items-center my-5">
+                <div className="h-px w-full bg-gray-400"></div>
+              </div>
+              <div className="flex flex-row justify-center mt-10">
+                <span className="mr-1.5 text-sm font-medium">
+                로그인 화면으로
+                </span>
+                <span
+                  className="text-sm font-bold text-blue-800 cursor-pointer ml-3"
+                  onClick={() => navigate("/")}
+                >
+                  이동하기
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default index;

--- a/frontend/src/pages/LoginPage/components/password/passwordreset/index.jsx
+++ b/frontend/src/pages/LoginPage/components/password/passwordreset/index.jsx
@@ -11,7 +11,7 @@ const index = () => {
 //   //테스트
 //   const mock = new MockAdapter(axios);
 //   mock
-//     .onPost("http://50.19.246.89:8080/api/v1/auth/password/reset?")
+//     .onPost("http://50.19.246.89:8080/api/v1/auth/password/reset/check")
 //     .reply(200, {
 //         code: 200,
 //         message: "비밀번호 재설정이 완료되었습니다.",
@@ -36,7 +36,7 @@ const index = () => {
     }
     try {
       const response = await axios.post(
-        "http://50.19.246.89:8080/api/v1/auth/password/reset?",
+        "http://50.19.246.89:8080/api/v1/auth/password/reset/check",
         {
           token, // 서버로 URL에서 추출한 토큰 전달
           newPassword, // 새로운 비밀번호 전달

--- a/frontend/src/pages/LoginPage/components/password/passwordreset/index.jsx
+++ b/frontend/src/pages/LoginPage/components/password/passwordreset/index.jsx
@@ -1,0 +1,144 @@
+import React, { useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import axios from "axios";
+import backImage from "../../../background.png";
+import logoImage from "../../../네카라쿠배.png";
+// import MockAdapter from "axios-mock-adapter";
+
+const index = () => {
+  const navigate = useNavigate();
+
+//   //테스트
+//   const mock = new MockAdapter(axios);
+//   mock
+//     .onPost("http://50.19.246.89:8080/api/v1/auth/password/reset?")
+//     .reply(200, {
+//         code: 200,
+//         message: "비밀번호 재설정이 완료되었습니다.",
+//     });
+
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const token = queryParams.get("token");
+
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmNewPassword, setConfirmNewPassword] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleNewPassword = (e) => setNewPassword(e.target.value);
+  const handleConfirmNewPassword = (e) => setConfirmNewPassword(e.target.value);
+
+  const handlePasswordReset = async () => {
+    // 비밀번호 확인
+    if (newPassword !== confirmNewPassword) {
+      setMessage("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+    try {
+      const response = await axios.post(
+        "http://50.19.246.89:8080/api/v1/auth/password/reset?",
+        {
+          token, // 서버로 URL에서 추출한 토큰 전달
+          newPassword, // 새로운 비밀번호 전달
+        }
+      );
+
+      if (response.data.code === "200") {
+        setMessage("비밀번호 재설정이 완료되었습니다.");
+        navigate("/");
+      } else {
+        setMessage(response.data.message);
+      }
+    } catch (error) {
+      console.error("Failed to reset password:", error);
+      setMessage("비밀번호 재설정 중 오류가 발생했습니다. 다시 시도해주세요.");
+    }
+  };
+
+  // 뒤로가기 함수
+  const goBack = () => {
+    navigate(-1);
+  };
+
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center bg-transparent"
+      style={{
+        backgroundImage: `url(${backImage})`,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+      }}
+    >
+      <div>
+        <div className="flex flex-row bg-white rounded-2xl">
+          <div className="w-96 h-full">
+            <div className="border border-gray-300 p-12 rounded-2xl">
+              <div className="pb-10 w-full">
+                <img
+                  className="w-full h-16"
+                  src={logoImage}
+                  alt="로고 이미지"
+                />
+                <div className="mt-8 text-center">
+                  <span className="text-2xl font-bold">
+                    비밀번호를 재설정합니다.
+                  </span>
+                </div>
+                <div className="mt-4 text-center">
+                  <span className="text-sm font-medium">
+                    새 비밀번호를 입력 후
+                  </span>
+                </div>
+                <div className="mt-1 mb-7 text-center">
+                  <span className="text-sm font-medium">
+                    완료 버튼을 눌러주세요.
+                  </span>
+                </div>
+                <div>
+                  <input
+                    className="w-full bg-gray-200 border border-gray-300  py-3 mb-2 pl-2 shadow-lg hover:shadow-xl"
+                    type="password"
+                    value={newPassword}
+                    onChange={handleNewPassword}
+                    placeholder="새 비밀번호"
+                  />
+                  <input
+                    className="w-full bg-gray-200 border border-gray-300 py-3 mt-5 mb-2 pl-2 shadow-lg hover:shadow-xl"
+                    type="password"
+                    value={confirmNewPassword}
+                    onChange={handleConfirmNewPassword}
+                    placeholder="새 비밀번호 확인"
+                  />
+                  <button
+                    className="mt-10 w-full flex-shrink-0 bg-white border border-blue-600 rounded-2xl hover:bg-blue-200 text-blue-600 px-4 shadow-lg hover:shadow-xl h-12 "
+                    onClick={handlePasswordReset}
+                  >
+                    완료
+                  </button>
+                </div>
+                {message && (
+                  <div className="mt-12 text-center">
+                    <span>{message}</span>
+                  </div>
+                )}
+              </div>
+              <div className="flex justify-between items-center my-5">
+                <div className="h-px w-full bg-gray-400"></div>
+              </div>
+              <div className="flex flex-row justify-center mt-10">
+                <span
+                  className="text-sm font-bold text-blue-800 cursor-pointer ml-3"
+                  onClick={goBack}
+                >
+                  돌아가기
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default index;

--- a/frontend/src/pages/LoginPage/components/signup/index.jsx
+++ b/frontend/src/pages/LoginPage/components/signup/index.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import logoImage from "../../네카라쿠배.png";
 import backImage from "../../background.png";
 import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
+// import MockAdapter from "axios-mock-adapter";
 
 const index = () => {
   const navigate = useNavigate();
@@ -20,17 +20,17 @@ const index = () => {
     setLoginValues((prevValues) => ({ ...prevValues, [name]: value }));
   };
 
-  //테스트
-  const mock = new MockAdapter(axios);
-  mock.onPost("http://localhost:8080/api/v1/auth/email").reply(200, {
-    message: "인증번호를 전송하였습니다.",
-  });
-  mock.onPost("http://localhost:8080/api/v1/auth/email/verify").reply(200, {
-    message: "인증 완료되었습니다.",
-  });
-  mock.onPost("http://localhost:8080/api/v1/auth/signup").reply(200, {
-    message: "회원가입이 완료되었습니다.",
-  });
+  // //테스트
+  // const mock = new MockAdapter(axios);
+  // mock.onPost("http://localhost:8080/api/v1/auth/email").reply(200, {
+  //   message: "인증번호를 전송하였습니다.",
+  // });
+  // mock.onPost("http://localhost:8080/api/v1/auth/email/verify").reply(200, {
+  //   message: "인증 완료되었습니다.",
+  // });
+  // mock.onPost("http://localhost:8080/api/v1/auth/signup").reply(200, {
+  //   message: "회원가입이 완료되었습니다.",
+  // });
 
   //이메일 인증
   const [verificationCode, setVerificationCode] = useState("");
@@ -44,7 +44,7 @@ const index = () => {
     try {
       // 이메일 인증번호 발송 API 호출
       const response = await axios.post(
-        "http://localhost:8080/api/v1/auth/email",
+        "http://50.19.246.89:8080/api/v1/auth/email",
         { email: loginValues.email }
       );
       if (response.data && response.data.message) {
@@ -70,19 +70,19 @@ const index = () => {
     try {
       // 인증 코드 확인 API 호출
       const response = await axios.post(
-        "http://localhost:8080/api/v1/auth/email/verify",
+        "http://50.19.246.89:8080/api/v1/auth/email/verify",
         {
           email: loginValues.email,
-          certificationNumber: verificationCode,
+          authNumber: verificationCode,
         }
       );
-      if (response.data && response.data.message) {
+      if (response.data.code === "200") {
         alert(response.data.message);
         setIsEmailVerified(false); // 인증에 성공하면 UI 숨김
         setSuccessCode(true); // 코드 인증 성공
         // 추가적인 로직 (예: 인증 성공 시 처리 등)
       } else {
-        alert("인증 코드가 올바르지 않습니다.");
+        alert(response.data.message);
       }
     } catch (error) {
       console.error("Code verification error!", error);
@@ -113,7 +113,7 @@ const index = () => {
     }
     try {
       const response = await axios.post(
-        "http://localhost:8080/api/v1/auth/signup",
+        "http://50.19.246.89:8080/api/v1/auth/signup",
         {
           email: loginValues.email,
           password: loginValues.password,

--- a/frontend/src/pages/LoginPage/components/signup/index.jsx
+++ b/frontend/src/pages/LoginPage/components/signup/index.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 import logoImage from "../../네카라쿠배.png";
 import backImage from "../../background.png";
 import axios from "axios";
-// import MockAdapter from "axios-mock-adapter";
 
 const index = () => {
   const navigate = useNavigate();
@@ -19,18 +18,6 @@ const index = () => {
     const { name, value } = e.target;
     setLoginValues((prevValues) => ({ ...prevValues, [name]: value }));
   };
-
-  // //테스트
-  // const mock = new MockAdapter(axios);
-  // mock.onPost("http://localhost:8080/api/v1/auth/email").reply(200, {
-  //   message: "인증번호를 전송하였습니다.",
-  // });
-  // mock.onPost("http://localhost:8080/api/v1/auth/email/verify").reply(200, {
-  //   message: "인증 완료되었습니다.",
-  // });
-  // mock.onPost("http://localhost:8080/api/v1/auth/signup").reply(200, {
-  //   message: "회원가입이 완료되었습니다.",
-  // });
 
   //이메일 인증
   const [verificationCode, setVerificationCode] = useState("");
@@ -70,7 +57,7 @@ const index = () => {
     try {
       // 인증 코드 확인 API 호출
       const response = await axios.post(
-        "http://50.19.246.89:8080/api/v1/auth/email/verify",
+        "http://50.19.246.89:8080/api/v1/auth/email/check",
         {
           email: loginValues.email,
           authNumber: verificationCode,

--- a/frontend/src/pages/LoginPage/index.jsx
+++ b/frontend/src/pages/LoginPage/index.jsx
@@ -1,5 +1,7 @@
 import LogIn from "./components/login";
 import SignUp from "./components/signup";
+import PasswordEmail from "./components/password/passwordemail";
+import PasswordReset from "./components/password/passwordreset";
 import { Routes, Route } from "react-router-dom";
 import React from "react";
 
@@ -9,6 +11,8 @@ const index = () => {
       <Routes>
         <Route path="/" element={<LogIn />} />
         <Route path="signup" element={<SignUp />} />
+        <Route path="password" element={<PasswordEmail />} />
+        <Route path="reset" element={<PasswordReset />} />
       </Routes>
     </div>
   );

--- a/frontend/src/service/axiosInstance.js
+++ b/frontend/src/service/axiosInstance.js
@@ -1,0 +1,20 @@
+import axios from "axios";
+
+const instance = axios.create({
+  baseURL: "http://50.19.246.89:8080/api/v1/",
+});
+
+instance.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem("token");
+    if (token) {
+      config.headers["Authorization"] = token;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+export default instance;


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?

## 작업 내용
비밀번호 재설정 페이지 추가
로그인 시 user 데이터 전송
## 스크린샷
![231006-1](https://github.com/NaKaLiGoBa/WebIDE/assets/135569766/e7822121-e616-4d9b-9f13-2f407c22a818)
![231006-2](https://github.com/NaKaLiGoBa/WebIDE/assets/135569766/2d4a1640-abf6-4801-8813-55d68ee9868b)
![231006-3](https://github.com/NaKaLiGoBa/WebIDE/assets/135569766/ec97e5e7-e773-4297-8f04-d785c039514c)

## 주의사항
로그인 시 user 데이터 전송을 추가했지만, 아직 오류가 많이 뜹니다. 
일단 임시로 URL을 http://50.19.246.89:8080/api/v1/user 를 사용해서 그런 것 같습니다
