### PR TITLE
[fix] Invite API 추가 및 프로젝트 목록 불러오기 서비스 로직 수정

### DIFF
--- a/backend/src/main/java/com/nakaligoba/backend/entity/MemberProjectEntity.java
+++ b/backend/src/main/java/com/nakaligoba/backend/entity/MemberProjectEntity.java
@@ -29,9 +29,9 @@ public class MemberProjectEntity extends BaseEntity {
     private MemberEntity member;
 
     @Builder
-    public MemberProjectEntity(Role role, ProjectEntity project, MemberEntity member) {
-        this.role = role;
+    public MemberProjectEntity(ProjectEntity project, MemberEntity member, Role role) {
         this.project = project;
         this.member = member;
+        this.role = role;
     }
 }

--- a/backend/src/main/java/com/nakaligoba/backend/entity/ProjectEntity.java
+++ b/backend/src/main/java/com/nakaligoba/backend/entity/ProjectEntity.java
@@ -30,6 +30,9 @@ public class ProjectEntity extends BaseEntity {
     @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<FileEntity> files = new ArrayList<>();
 
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
+    private List<MemberProjectEntity> collaborators = new ArrayList<>();
+
     @Builder
     public ProjectEntity(String name, String description, String storageId) {
         this.name = name;

--- a/backend/src/main/java/com/nakaligoba/backend/repository/MemberProjectRepository.java
+++ b/backend/src/main/java/com/nakaligoba/backend/repository/MemberProjectRepository.java
@@ -2,10 +2,15 @@ package com.nakaligoba.backend.repository;
 
 import com.nakaligoba.backend.entity.MemberEntity;
 import com.nakaligoba.backend.entity.MemberProjectEntity;
+import com.nakaligoba.backend.entity.ProjectEntity;
+import com.nakaligoba.backend.entity.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberProjectRepository extends JpaRepository<MemberProjectEntity, Long> {
     MemberProjectEntity findByMemberAndProjectId(MemberEntity member, Long projectId);
+    List<MemberProjectEntity> findByMember(MemberEntity member);
+    Optional<MemberProjectEntity> findByProjectAndMemberAndRole(ProjectEntity project, MemberEntity member, Role role);
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?

## 작업 내용

- projectController
: @DeleteMapping에 '/'가 빠져 추가하였습니다.
: invite API를 추가하였습니다.
-> 초대하는 이메일(로그인시)과 초대당하는 이메일(입력창)을 받아 Service Layer에서
초대하는 사람이 OWNER인지 DB에서 조회한 후 Null이 아니면 
해당 초대받는 사람이 MemberProjectRepository에 를 저장 후,
프로젝트 객체와 초대받는 객체와 COLLABORATOR를 저장합니다.

- MemberProjectEntity
: 생성자의 매개변수 위치를 변경하였습니다.

- ProjectEntity
: collaborators 리스트 필드를 추가하였습니다.

- MemberProjectRepository
: 리포지토리를 조회하는 메서드를 추가하였습니다.

- ProjectService
: 프로젝트파일 목록을 불러오는 메소드명을 getAllProjects() ->getProjectsByEmail(String email) 로 변경하였습니다.
collaborators 리스트에 담긴 인원들을 getCollaborators로 불러와 ProjectListResponse 객체에 담아 응답으로 보내도록 하였습니다.

## 스크린샷

## 주의사항

Closes #{issueNumber}
