### PR TITLE
[fix] 초대된 인원 삭제 API 추가 및 파일 삭제 API 수정

### DIFF
--- a/backend/src/main/java/com/nakaligoba/backend/controller/FileController.java
+++ b/backend/src/main/java/com/nakaligoba/backend/controller/FileController.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import com.nakaligoba.backend.service.FileService.*;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.ws.rs.Path;
+import java.util.NoSuchElementException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -88,12 +90,20 @@ public class FileController {
     }
 
     @DeleteMapping("/{fileId}")
-    public ResponseEntity<Void> deleteFile(
+    public ResponseEntity<String> deleteFile(
             @PathVariable Long projectId,
             @PathVariable Long fileId
     ) {
-        fileService.deleteFile(projectId, fileId);
-        return ResponseEntity.ok().build();
+        try {
+            fileService.deleteFile(projectId, fileId);
+            return ResponseEntity.ok("파일이 삭제되었습니다.");
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("파일 삭제 중 오류가 발생했습니다.");
+        }
     }
 
     @Data

--- a/backend/src/main/java/com/nakaligoba/backend/controller/ProjectController.java
+++ b/backend/src/main/java/com/nakaligoba/backend/controller/ProjectController.java
@@ -1,5 +1,7 @@
 package com.nakaligoba.backend.controller;
 
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.exception.UnauthorizedException;
 import com.nakaligoba.backend.entity.Role;
 import com.nakaligoba.backend.service.ProjectService;
 import com.nakaligoba.backend.service.ProjectService.CreateProjectDto;
@@ -9,6 +11,7 @@ import com.nakaligoba.backend.utils.JwtUtils;
 import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -90,6 +93,22 @@ public class ProjectController {
             return ResponseEntity.ok().build();
         } catch (IllegalArgumentException ex) {
             return ResponseEntity.badRequest().body(ex.getMessage());
+        }
+    }
+
+    @DeleteMapping("/{id}/members/{memberId}")
+    public ResponseEntity<?> removeProjectMember (
+            @PathVariable Long id,
+            @PathVariable Long memberId
+    ){
+        String email = jwtUtils.getEmailFromSpringSession();
+        try {
+            projectService.removeMemberToProject(id, memberId, email);
+            return ResponseEntity.ok().build();
+        } catch (NotFoundException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (UnauthorizedException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
         }
     }
 

--- a/backend/src/main/java/com/nakaligoba/backend/service/FileService.java
+++ b/backend/src/main/java/com/nakaligoba/backend/service/FileService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
@@ -130,8 +131,13 @@ public class FileService {
                 .filter(file -> Objects.equals(file.getId(), fileId))
                 .findAny()
                 .orElseThrow(() -> new NoSuchElementException("해당 ID의 파일을 찾을 수 없습니다."));
-
         fileRepository.delete(fileEntity);
+
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(BUCKET_NAME)
+                .key(fileEntity.getStorageFileId())
+                .build();
+        s3Client.deleteObject(deleteObjectRequest);
     }
 
     @Data


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?

## 작업 내용
- 파일 삭제 API 로직에서 S3 관련 로직을 추가하였습니다.
- collaborator 삭제 로직은 
- (현재 접속한 유저가 해당 프로젝트에 존재하는지) 또는 (해당 프로젝트에서 OWNER인지) 먼저 검사 합니다.
- 삭제당하는 유저는 (DB에 저장되어있는 유저인지) 검사하고, (해당 프로젝트에 존재하는지)를 검사합니다.
- 모두 다 검증이 된 경우, 삭제 당하는 유저는 collaborator 컬럼에서 제외하고, MemberProjectRepository에서 제거함으로써 


그 유저는 해당 프로젝트와 연결을 제거하는 방식으로 진행하였습니다.

## 스크린샷

## 주의사항

Closes #{issueNumber}
